### PR TITLE
Re-enable the button after submitting

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -30,7 +30,8 @@
               :value => @initial_code %>
         </p>
         <p>
-          <%= f.submit "Generate Layout Code", class: 'btn btn-success' %>
+          <%= f.submit "Generate Layout Code", class: 'btn btn-success', 
+            data: { disable_with: false } %>
           <button type="button" class="btn btn-default" id="link_button">Permalink</button>
           <div id='link'></div>
         </p>


### PR DESCRIPTION
In Rails 6 it seems the submit button is disabled by default, so
that behavior needs to be changed. See this page for details:

https://stackoverflow.com/questions/42016113/rails-data-disable-with-re-enabling-button