### PR TITLE
Use the -isystem flag to set the include path

### DIFF
--- a/app/services/execute_layout.rb
+++ b/app/services/execute_layout.rb
@@ -3,17 +3,11 @@
 require 'open3'
 
 class ExecuteLayout
-  @@includes = '-Iusr/lib/llvm-5.0/lib/clang/5.0.0/include '\
-               '-Iusr/include/c++/7.2.0 '\
-               '-Iusr/include/x86_64-linux-gnu/c++/7 '\
-               '-Iusr/include/c++/7.2.0/backward '\
-               '-Iusr/include/x86_64-linux-gnu '\
-               '-Iusr/include'
   def self.call(path, flags)
     Dir.chdir('layout-package') do
       stdout, stderr, status = Open3.capture3(
         { 'LD_LIBRARY_PATH' => '.' },
-        "./layout #{path} #{@@includes} #{flags}"
+        "./layout #{path} -isystem usr/include #{flags}"
       )
       return stdout, strip_filenames(stderr), status
     end


### PR DESCRIPTION
This is better than custom -I flags, as really we want to specify the
defauklt system include path.